### PR TITLE
Change port from 4242 to 2375

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A simple nginx instance which proxies the docker socket, allowing you to expose 
 
 Run with:
 
-    docker run -d -p 4242:4242 -v /var/run/docker.sock:/var/run/docker.sock bobtfish/docker-socket-http-proxy
+    docker run -d -p 2375:2375 -v /var/run/docker.sock:/var/run/docker.sock bobtfish/docker-socket-http-proxy
 
 BEWARE - allowing people access to the docker API is functionally equivalent to handing them root permissions :)
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,7 +11,7 @@ http {
         server unix:/var/run/docker.sock fail_timeout=0;
     }
     server {
-        listen 4242;
+        listen 2375;
         server_name localhost;
  
         access_log /dev/stdout combined;


### PR DESCRIPTION
since it is the port suggested in the Docker documentation:
https://docs.docker.com/articles/basics/#bind-docker-to-another-host-port-or-a-unix-socket
