### PR TITLE
Changed paths and user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM nginx:1.7
 ENV DEBIAN_FRONTEND noninteractive
 
-ADD nginx.conf /etc/nginx.conf
+ADD nginx.conf /etc/nginx/nginx.conf
+USER root
 
-EXPOSE 4242
+EXPOSE 2375
 
-CMD ["/usr/local/sbin/nginx"]
+CMD ["/usr/sbin/nginx"]
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,4 +1,5 @@
 worker_processes  1;
+user root;
 
 events {
     worker_connections  1024;


### PR DESCRIPTION
This PR fixes nginx paths for configuration and executable, and user that runs nginx proxy (root user, if you use default user, the docker connection fails in newer version due to permission denied).
Thanks for the work ;-)